### PR TITLE
add orders queue and associated config

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -7,6 +7,8 @@ param appServiceAppName string = 'toylaunch${uniqueString(resourceGroup().id)}'
 @description('The name of the storage account to deploy. This name must be globally unique.')
 param storageAccountName string = 'toylaunch${uniqueString(resourceGroup().id)}'
 
+var processOrderQueueName = 'processorder'
+
 @description('The type of the environment. This must be nonprod or prod.')
 @allowed([
   'nonprod'
@@ -26,6 +28,14 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   properties: {
     accessTier: 'Hot'
   }
+
+  resource queueServices 'queueServices' existing = {
+    name: 'default'
+    
+    resource processOrderQueue 'queues' = {
+      name: processOrderQueueName
+    }
+  }
 }
 
 module appService 'modules/appService.bicep' = {
@@ -34,6 +44,8 @@ module appService 'modules/appService.bicep' = {
     location: location
     appServiceAppName: appServiceAppName
     environmentType: environmentType
+    storageAccountName: storageAccount.name
+    processOrderQueueName: storageAccount::queueServices::processOrderQueue.name
   }
 }
 

--- a/deploy/modules/appService.bicep
+++ b/deploy/modules/appService.bicep
@@ -4,6 +4,12 @@ param location string
 @description('The name of the App Service app to deploy. This name must be globally unique.')
 param appServiceAppName string
 
+@description('The name of the storage account to deploy. This name must be globally unique.')
+param storageAccountName string
+
+@description('The name of the queue to deploy for processing orders.')
+param processOrderQueueName string
+
 @description('The type of the environment. This must be nonprod or prod.')
 @allowed([
   'nonprod'
@@ -28,6 +34,18 @@ resource appServiceApp 'Microsoft.Web/sites@2022-03-01' = {
   properties: {
     serverFarmId: appServicePlan.id
     httpsOnly: true
+    siteConfig: {
+      appSettings:[
+        {
+          name: 'storageAccountName'
+          value: storageAccountName
+        }
+        {
+          name: 'processOrderQueueName'
+          value: processOrderQueueName
+        }
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a new Azure Storage queue for processing orders, and updates the website configuration to include the storage account and queue information.